### PR TITLE
Center working hours highlight controls

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -45,6 +45,7 @@ body {
   flex-wrap: wrap;
   gap: 8px;
   margin-bottom: 12px;
+  align-items: center;
 }
 input, select, button {
   height: 38px;


### PR DESCRIPTION
## Summary
- Vertically centers items within `.inputs` so the working hours controls align with the rest of the input row.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4572f1f1c832a874224f2b7767799