### PR TITLE
feat: auto-detect timezone and persist settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,5 @@ npm run preview
 - Use IANA time zones like `Asia/Kolkata` or city aliases (e.g., Bengaluru, Stockholm, New York).
 - Working hours highlighting is configurable.
 - No external APIs required; the browser formats times with `Intl.DateTimeFormat`.
+- Local time zone is detected automatically on first load.
+- Selected locations and working-hour preferences persist via `localStorage`.


### PR DESCRIPTION
## Summary
- Automatically insert the user's local time zone on first load
- Save selected locations and working-hour preferences in localStorage
- Autofocus the time zone input for quicker entry

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a47865b0b0832ab8b13fdb6275a351