### PR TITLE
Fix icon alignment in location tags

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -110,6 +110,7 @@ button:active {
   width: 24px;
   display: grid;
   place-items: center;
+  padding: 0;
   border-radius: 999px;
   background: transparent;
   color: var(--muted);


### PR DESCRIPTION
## Summary
- ensure location tag action buttons center their icons by removing default padding

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a47a1c0cc8832aa170c71e01721d3b